### PR TITLE
Check for github action updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+
+  - package-ecosystem: "npm"
+    directory: "/client"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "client"
+      - "dependencies"
+      - "npm"
+
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "server"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This will use dependabot to check for updates on github actions which this project uses on a monthly basis.

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
