### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/branch-pr-release.yaml
+++ b/.github/workflows/branch-pr-release.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/template-schema-updater.yaml
+++ b/.github/workflows/template-schema-updater.yaml
@@ -3,6 +3,10 @@ on:
   schedule:
     - cron: '0 */8 * * *'
   workflow_dispatch: # Enables on-demand/manual triggering: https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/manually-running-a-workflow
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   schema-updater:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.