### PR TITLE
fix: run cfn-lint without a shell to prevent command injection

### DIFF
--- a/client/src/test/suite/commandTokenizer.test.ts
+++ b/client/src/test/suite/commandTokenizer.test.ts
@@ -1,0 +1,111 @@
+import * as assert from "assert";
+import * as path from "path";
+
+// The tokenizer lives in the language server package. The client tsconfig sets
+// rootDir to "src", so it cannot be TS-imported across packages; require the
+// compiled server output at runtime instead (the server is compiled before the
+// tests run via `npm run compile`).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { tokenizeCommand } = require(path.resolve(
+  __dirname,
+  "../../../../server/out/utils/commandTokenizer"
+)) as { tokenizeCommand: (command: string) => string[] };
+
+suite("tokenizeCommand", () => {
+  suite("preserves legitimate configuration", () => {
+    test("a bare executable name is a single token", () => {
+      assert.deepStrictEqual(tokenizeCommand("cfn-lint"), ["cfn-lint"]);
+    });
+
+    test("arguments embedded in the path are split on whitespace", () => {
+      assert.deepStrictEqual(
+        tokenizeCommand("cfn-lint --registry-schemas /some/dir"),
+        ["cfn-lint", "--registry-schemas", "/some/dir"]
+      );
+    });
+
+    test("collapses runs of whitespace and ignores tabs", () => {
+      assert.deepStrictEqual(tokenizeCommand("cfn-lint\t-c  I"), [
+        "cfn-lint",
+        "-c",
+        "I",
+      ]);
+    });
+
+    test("a quoted path containing spaces stays one token", () => {
+      assert.deepStrictEqual(tokenizeCommand('"/opt/my tools/cfn-lint"'), [
+        "/opt/my tools/cfn-lint",
+      ]);
+      assert.deepStrictEqual(tokenizeCommand("'/opt/my tools/cfn-lint'"), [
+        "/opt/my tools/cfn-lint",
+      ]);
+    });
+
+    test("a backslash escapes a space outside quotes", () => {
+      assert.deepStrictEqual(tokenizeCommand("/opt/my\\ tools/cfn-lint"), [
+        "/opt/my tools/cfn-lint",
+      ]);
+    });
+
+    test("empty or whitespace-only input yields no tokens", () => {
+      assert.deepStrictEqual(tokenizeCommand(""), []);
+      assert.deepStrictEqual(tokenizeCommand("   \t "), []);
+    });
+  });
+
+  // These are the security-relevant cases: shell metacharacters must survive as
+  // inert literal argv tokens, never as separators or operators. Because the
+  // process is spawned with shell:false, a single token can only ever be one
+  // argument to cfn-lint, so none of these can start a new command.
+  suite("does not interpret shell metacharacters", () => {
+    test("a semicolon does not start a new command", () => {
+      assert.deepStrictEqual(tokenizeCommand("cfn-lint; touch /tmp/pwned"), [
+        "cfn-lint;",
+        "touch",
+        "/tmp/pwned",
+      ]);
+    });
+
+    test("command substitution is kept literal", () => {
+      assert.deepStrictEqual(tokenizeCommand("cfn-lint $(touch /tmp/pwned)"), [
+        "cfn-lint",
+        "$(touch",
+        "/tmp/pwned)",
+      ]);
+    });
+
+    test("backticks are kept literal", () => {
+      assert.deepStrictEqual(tokenizeCommand("`touch /tmp/pwned`"), [
+        "`touch",
+        "/tmp/pwned`",
+      ]);
+    });
+
+    test("pipe and logical operators are kept literal", () => {
+      assert.deepStrictEqual(tokenizeCommand("cfn-lint | sh && rm -rf /"), [
+        "cfn-lint",
+        "|",
+        "sh",
+        "&&",
+        "rm",
+        "-rf",
+        "/",
+      ]);
+    });
+
+    test("metacharacters inside double quotes are not expanded", () => {
+      assert.deepStrictEqual(tokenizeCommand('cfn-lint "$(id)`whoami`;rm"'), [
+        "cfn-lint",
+        "$(id)`whoami`;rm",
+      ]);
+    });
+
+    test("a redirection character is kept literal", () => {
+      assert.deepStrictEqual(tokenizeCommand("cfn-lint > /etc/passwd"), [
+        "cfn-lint",
+        ">",
+        "/etc/passwd",
+      ]);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -108,22 +108,26 @@
         "cfnLint.path": {
           "type": "string",
           "default": "cfn-lint",
-          "description": "Path to cfn-lint"
+          "scope": "machine-overridable",
+          "description": "Path to cfn-lint. For security this can only be set in user or remote (machine) settings, not in workspace/folder settings, because it controls which executable is launched."
         },
         "cfnLint.appendRules": {
           "type": "array",
           "default": [],
-          "description": "Append Rules Directories"
+          "scope": "machine-overridable",
+          "description": "Append Rules Directories. For security this can only be set in user or remote (machine) settings, not in workspace/folder settings, because cfn-lint loads and executes code from these directories."
         },
         "cfnLint.ignoreRules": {
           "type": "array",
           "default": [],
-          "description": "Ignore Rules"
+          "scope": "machine-overridable",
+          "description": "Ignore Rules. Set in user or remote (machine) settings; not honored from workspace/folder settings because it is passed to the cfn-lint process."
         },
         "cfnLint.overrideSpecPath": {
           "type": "string",
           "default": "",
-          "description": "(Optional) Path to an override specfile json file"
+          "scope": "machine-overridable",
+          "description": "(Optional) Path to an override specfile json file. Set in user or remote (machine) settings; not honored from workspace/folder settings because it is passed to the cfn-lint process."
         },
         "cfnLint.format.enable": {
           "type": "boolean",

--- a/server/src/server/handlers/validationHandler.ts
+++ b/server/src/server/handlers/validationHandler.ts
@@ -179,7 +179,10 @@ export class ValidationHandler extends YamlValidationHandler {
           );
         }
 
-        args.push("--", `"${fileToLint}"`);
+        // Pass the file name as its own argv entry (no shell, no quoting) so a
+        // crafted file name cannot be interpreted as a command. `--` still
+        // guards against a name that begins with a dash being read as a flag.
+        args.push("--", fileToLint);
 
         this.cfnConnection.console.log(
           `Running... ${this.cfnSettings.cfnLintPath} ${args}`

--- a/server/src/service/services/cfnValidation.ts
+++ b/server/src/service/services/cfnValidation.ts
@@ -16,6 +16,7 @@ permissions and limitations under the License.
 
 import { spawn, ChildProcess } from "child_process";
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
+import { tokenizeCommand } from "../../utils/commandTokenizer";
 
 export class CfnValidation {
   child: ChildProcess;
@@ -25,8 +26,12 @@ export class CfnValidation {
   end: number;
 
   constructor(cmd: string, params: string[]) {
-    this.child = spawn(cmd, params, {
-      shell: true,
+    // Split any arguments embedded in the configured path without a shell, then
+    // launch with shell:false so no argument (including the template file name
+    // appended by the caller) can be interpreted as a shell command.
+    const [executable, ...embeddedArgs] = tokenizeCommand(cmd);
+    this.child = spawn(executable, [...embeddedArgs, ...params], {
+      shell: false,
     });
     this.start = 0;
     this.end = Number.MAX_VALUE;

--- a/server/src/service/services/cfnVersion.ts
+++ b/server/src/service/services/cfnVersion.ts
@@ -16,6 +16,7 @@ permissions and limitations under the License.
 
 import { spawn, ChildProcess } from "child_process";
 import { Diagnostic } from "vscode-languageserver";
+import { tokenizeCommand } from "../../utils/commandTokenizer";
 
 export class CfnVersion {
   child: ChildProcess;
@@ -25,8 +26,12 @@ export class CfnVersion {
   end: number;
 
   constructor(cmd: string) {
-    this.child = spawn(cmd, ["--version"], {
-      shell: true,
+    // Split any arguments embedded in the configured path without a shell, then
+    // launch with shell:false so nothing in the path can be interpreted as a
+    // shell command.
+    const [executable, ...embeddedArgs] = tokenizeCommand(cmd);
+    this.child = spawn(executable, [...embeddedArgs, "--version"], {
+      shell: false,
     });
     this.start = 0;
     this.end = Number.MAX_VALUE;

--- a/server/src/utils/commandTokenizer.ts
+++ b/server/src/utils/commandTokenizer.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+/**
+ * Splits a command string into an argv-style array WITHOUT invoking a shell.
+ *
+ * The `cfnLint.path` setting is allowed to carry embedded arguments (for
+ * example `cfn-lint --registry-schemas /some/dir`). Historically the process
+ * was launched with `{ shell: true }`, which honored that embedded-argument
+ * form but also made every shell metacharacter (`;`, `|`, `$(...)`, backticks,
+ * `&&`, redirection, ...) executable. This tokenizer keeps the quote-aware,
+ * whitespace-separated splitting users rely on while performing NO expansion
+ * or substitution, so any metacharacter is carried through verbatim as a
+ * literal argv token instead of being interpreted by a shell.
+ *
+ * Supported quoting mirrors POSIX literal quoting only:
+ *   - single quotes: everything between them is literal
+ *   - double quotes: everything between them is literal (no variable or
+ *     command substitution, since no shell is involved)
+ *   - a backslash escapes the next character outside single quotes
+ *
+ * @param command raw command string (may be empty)
+ * @returns argv tokens; the first entry is the executable
+ */
+export function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let hasToken = false;
+  let quote: '"' | "'" | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      hasToken = true;
+      continue;
+    }
+
+    // Backslash escapes the next char except inside single quotes.
+    if (ch === "\\" && quote !== "'") {
+      escaped = true;
+      hasToken = true;
+      continue;
+    }
+
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+      hasToken = true;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      hasToken = true;
+      continue;
+    }
+
+    if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+      if (hasToken) {
+        tokens.push(current);
+        current = "";
+        hasToken = false;
+      }
+      continue;
+    }
+
+    current += ch;
+    hasToken = true;
+  }
+
+  if (hasToken) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}


### PR DESCRIPTION
The language server launched cfn-lint with `spawn(cmd, params, { shell: true })` in CfnValidation and CfnVersion, so the command line was interpreted by a shell. Combined with configuration that can carry arbitrary strings and a file name that was only wrapped in double quotes, shell metacharacters (`$(...)`, backticks, `;`, `|`, `&&`, redirection, ...) in those inputs could be executed rather than treated as literal values.

Harden process launching (defense in depth):
- Launch with `shell: false` and pass arguments as a real argv array, so no argument (the configured path, rule directories, or the template file name) is ever interpreted by a shell.
- Add `tokenizeCommand`, a shell-free, quote-aware tokenizer that preserves the existing "arguments embedded in cfnLint.path" behavior without performing any expansion or substitution.
- Pass the template file name as its own raw argv entry instead of a shell-quoted string.
- Mark `cfnLint.path`, `cfnLint.appendRules`, `cfnLint.ignoreRules` and `cfnLint.overrideSpecPath` as `machine-overridable` scope so these process-controlling values cannot be set by workspace/folder settings.

Add unit tests for tokenizeCommand covering both the legitimate embedded-argument and quoted-path forms and the shell-metacharacter cases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
