### PR TITLE
fix: treat backslash as a literal char in tokenizeCommand so Windows paths work

### DIFF
--- a/client/src/test/suite/commandTokenizer.test.ts
+++ b/client/src/test/suite/commandTokenizer.test.ts
@@ -41,10 +41,31 @@ suite("tokenizeCommand", () => {
       ]);
     });
 
-    test("a backslash escapes a space outside quotes", () => {
-      assert.deepStrictEqual(tokenizeCommand("/opt/my\\ tools/cfn-lint"), [
-        "/opt/my tools/cfn-lint",
-      ]);
+    test("backslashes are literal so Windows paths are preserved", () => {
+      assert.deepStrictEqual(
+        tokenizeCommand("C:\\Python311\\Scripts\\cfn-lint.exe"),
+        ["C:\\Python311\\Scripts\\cfn-lint.exe"]
+      );
+    });
+
+    test("a quoted Windows path with spaces stays one token", () => {
+      assert.deepStrictEqual(
+        tokenizeCommand('"C:\\Program Files\\Python\\cfn-lint.exe"'),
+        ["C:\\Program Files\\Python\\cfn-lint.exe"]
+      );
+    });
+
+    test("a Windows path with an embedded argument splits on whitespace only", () => {
+      assert.deepStrictEqual(
+        tokenizeCommand(
+          "C:\\Python311\\Scripts\\cfn-lint.exe --registry-schemas C:\\schemas"
+        ),
+        [
+          "C:\\Python311\\Scripts\\cfn-lint.exe",
+          "--registry-schemas",
+          "C:\\schemas",
+        ]
+      );
     });
 
     test("empty or whitespace-only input yields no tokens", () => {

--- a/server/src/utils/commandTokenizer.ts
+++ b/server/src/utils/commandTokenizer.ts
@@ -26,11 +26,13 @@ permissions and limitations under the License.
  * or substitution, so any metacharacter is carried through verbatim as a
  * literal argv token instead of being interpreted by a shell.
  *
- * Supported quoting mirrors POSIX literal quoting only:
+ * Quoting rules (backslash is deliberately NOT an escape character):
  *   - single quotes: everything between them is literal
  *   - double quotes: everything between them is literal (no variable or
  *     command substitution, since no shell is involved)
- *   - a backslash escapes the next character outside single quotes
+ *   - a backslash is an ordinary character, so Windows paths such as
+ *     `C:\Python\Scripts\cfn-lint.exe` are preserved verbatim. Paths that
+ *     contain spaces must be wrapped in quotes, exactly as before.
  *
  * @param command raw command string (may be empty)
  * @returns argv tokens; the first entry is the executable
@@ -40,24 +42,9 @@ export function tokenizeCommand(command: string): string[] {
   let current = "";
   let hasToken = false;
   let quote: '"' | "'" | null = null;
-  let escaped = false;
 
   for (let i = 0; i < command.length; i++) {
     const ch = command[i];
-
-    if (escaped) {
-      current += ch;
-      escaped = false;
-      hasToken = true;
-      continue;
-    }
-
-    // Backslash escapes the next char except inside single quotes.
-    if (ch === "\\" && quote !== "'") {
-      escaped = true;
-      hasToken = true;
-      continue;
-    }
 
     if (quote) {
       if (ch === quote) {


### PR DESCRIPTION
tokenizeCommand (added in #515) treated `\` as a shell-style escape that consumed the following character. That corrupted every Windows executable path: `C:\Python311\Scripts\cfn-lint.exe` tokenized to `C:Python311Scriptscfn-lint.exe`, so cfn-lint could not be launched and validation silently stopped working for Windows users whose `cfnLint.path` used backslashes.

Backslash escaping is unnecessary here because the process is spawned with `shell: false`; quoting alone is enough to carry spaces. Remove the escape handling so `\` is an ordinary character and Windows paths (including UNC paths and quoted paths that contain spaces) are preserved verbatim. Paths with spaces must still be wrapped in quotes, which is unchanged behavior.

Update the unit tests: drop the backslash-escape case and add coverage for a plain Windows path, a quoted Windows path with spaces, and a Windows path that carries an embedded argument. The shell-metacharacter cases are unchanged, so injection is still neutralized.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
