### PR TITLE
ci: skip duplicate versions when publishing the extension

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,9 +23,14 @@ jobs:
         id: publishToOpenVSX
         with:
           pat: ${{ secrets.OVSX_PAT }}
+          # Treat an already-published version as success so re-running the
+          # release (e.g. after fixing the Marketplace token) does not fail
+          # here before the Marketplace step gets a chance to run.
+          skipDuplicate: true
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VSCE_PAT }}
           registryUrl: https://marketplace.visualstudio.com
           extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          skipDuplicate: true


### PR DESCRIPTION
The release publish job runs Open VSX first, then the VS Code Marketplace. When the Marketplace step fails (for example an expired token) and the release is re-run, the Open VSX step aborts the whole job with "already published" before the Marketplace step can run, so the Marketplace never catches up.

Set skipDuplicate: true on both publish steps so an already-published version is treated as a successful no-op. Re-running a release now proceeds to every registry that is still behind instead of failing on the first one that is already up to date.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
